### PR TITLE
Fix tsc_freq overflow problem

### DIFF
--- a/pcie-lat.c
+++ b/pcie-lat.c
@@ -367,7 +367,7 @@ static ssize_t pcielat_tsc_freq_show(struct device *dev,
 				     struct device_attribute *attr,
 				     char *buf)
 {
-	return scnprintf(buf, PAGE_SIZE, "%u\n", tsc_khz * 1000);
+	return scnprintf(buf, PAGE_SIZE, "%llu\n", tsc_khz * 1000LLU);
 }
 
 static ssize_t pcielat_tsc_overhead_show(struct device *dev,


### PR DESCRIPTION
I had same issue as https://github.com/andre-richter/pcie-lat/issues/2

The problem is very simple: for my tsc_freq (4300 * 10^6) value is too big for uint32_t.